### PR TITLE
execSync only works on node 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "canonical-json": "0.0.x",
     "lodash": "3.10.x"
   },
+  "engines": {
+    "node": ">=0.12"
+  },
+  "engineStrict": true,
   "bin": {
     "meteor-jsdoc": "./bin/meteor-jsdoc"
   },


### PR DESCRIPTION
This sets `engines` to enforce node 0.12.

This is because `require("child_process").execSync` is only defined on node 0.12, and meteor-jsdoc will not run otherwise. So I guess either use this, or use a polyfill or workaround for earlier versions of node.
