### PR TITLE
api_box errors when trying to read `names` when `type` is not defined.

### DIFF
--- a/example/meteor/client/templates/api-box.js
+++ b/example/meteor/client/templates/api-box.js
@@ -146,7 +146,7 @@ Template.autoApiBox.helpers({
 
 Template.api_box_args.helpers({
   typeNames: function() {
-    return typeNames(this.type.names);
+    return this.type && typeNames(this.type.names);
   }
 });
 


### PR DESCRIPTION
If you build the docs at https://github.com/HarvardEconCS/turkserver-meteor/tree/master/docs, you will see the following error in the console after it loads:

![image](https://cloud.githubusercontent.com/assets/2080084/9206490/2af74004-4036-11e5-84cf-43ded9eedcf4.png)

This is due to the following line:

``` js
Template.api_box_args.helpers({
  typeNames: function() {
    return typeNames(this.type.names);
  }
});
```

This is because a type is not specified for some piece of documentation information.

Right now this error just causes some of the rest of the page to not render properly. But I don't think it should be swallowed either. If a piece of documentation is missing a type, a warning should be printed out in the compile process (or less optimally, in the console when rendering instead of throwing an error).

The simplest guard would just be `this.type && this.type.names`. Thoughts?
