### PR TITLE
Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This will create a config file in your Meteor project directory:
 
 ```js
 {
-  // node.js install path, default to: "`which node`"
+  // node.js install path, default to: "`which node`" on Mac and Linux, "`where node`" on Windows
   "nodePath": "",
   // Project docs path
   "docsPath": "~/myproject-docs",
@@ -190,6 +190,8 @@ Second:
     meteor
 
 This will start Meteor as usual with the possibility to `ctrl+c` when you want to stop it.
+
+First method doesn't currently work on Windows.
 
 ### Stopping the Meteor server
 

--- a/example/jsdoc.json
+++ b/example/jsdoc.json
@@ -1,5 +1,5 @@
 {
-  // node.js install path, default to: "`which node`"
+  // node.js install path, default to: "`which node`" on Mac and Linux, "`where node`" on Windows
   "nodePath": "",
   // Project docs path
   "docsPath": "~/myproject-docs",

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -180,7 +180,7 @@ Actions.prototype.build = function() {
 
   self._executeScript(build_docs.script, build_docs.vars, function(err, code, logs) {
     if (err) {
-      console.log(err.bold.red);
+      console.error(err.toString().bold.red);
     } else {
       var fatalErrors = logs.stderr;
       var cmdIndex    = fatalErrors.indexOf(self.config.nodePath + " " + jsdocPath);
@@ -202,7 +202,7 @@ Actions.prototype.build = function() {
 
         if (errors) {
           _.each(errors, function(error) {
-            console.log(error.replace("\n", "").bold.red, "\n");
+            console.error(error.toString().replace("\n", "").bold.red, "\n");
           });
           console.log("Docs built with errors.".bold.yellow);
         } else {
@@ -226,7 +226,7 @@ Actions.prototype.start = function() {
 
   self._executeScript(start_meteor.script, start_meteor.vars, function(err, code, logs) {
     if (err) {
-      console.log(err.bold.red);
+      console.error(err.toString().bold.red);
     } else {
       var log = "Meteor docs server starting at http://localhost:" + self.config.meteorPort + "/";
       console.log(log.bold.green);
@@ -247,7 +247,7 @@ Actions.prototype.stop = function() {
 
   self._executeScript(stop_meteor.script, stop_meteor.vars, function(err, code, logs) {
     if (err) {
-      console.log(err.bold.red);
+      console.error(err.toString().bold.red);
     } else {
       console.log("Meteor docs server stopped.".bold.green);
     }

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -2,6 +2,7 @@ var _        = require("lodash");
 var spawn    = require("child_process").spawn;
 var execSync = require("child_process").execSync;
 var fs       = require("fs");
+var os       = require("os");
 var path     = require("path");
 var ejs      = require("ejs");
 
@@ -49,7 +50,7 @@ Actions.prototype._execute = function(command, callback) {
   callback = callback || function() {};
 
   var self = this;
-  var tmpScript = "/tmp/" + self._randomId();
+  var tmpScript = os.tmpdir() + self._randomId();
   var logs = { stdout: "", stderr: ""};
   var bash;
 
@@ -134,10 +135,10 @@ Actions.prototype.build = function() {
   }
 
   if (self.config.initMeteor) {
-    execSync("cp -R " + METEOR_DIR + "/. " + self.config.docsPath + "/");
+    execSync("cp -R '" + METEOR_DIR + "/.' '" + self.config.docsPath + "/'");
     console.log("Meteor initialized.".bold.green);
   } else if (self.config.updateMeteor) {
-    execSync("cp -R " + METEOR_DIR + "/.meteor " + self.config.docsPath + "/");
+    execSync("cp -R '" + METEOR_DIR + "/.meteor' '" + self.config.docsPath + "/'");
     console.log("Meteor updated.".bold.green);
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,6 +3,7 @@ var execSync = require("child_process").execSync;
 var cjson    = require("cjson");
 var path     = require("path");
 var fs       = require("fs");
+var os       = require("os");
 var helpers  = require("./helpers");
 var format   = require("util").format;
 
@@ -19,7 +20,14 @@ exports.read = function() {
     }
 
     if (typeof jsdocJson.nodePath === "undefined" || _.isEmpty(jsdocJson.nodePath)) {
-      var nodePath = execSync("which node").toString().replace("\n", "");
+      var executableFinder;
+      if(os.platform() === "win32") {
+        executableFinder = "where";
+      }
+      else {
+        executableFinder = "which";
+      }
+      var nodePath = execSync(executableFinder + " node").toString().replace("\n", "");
 
       if (! nodePath) {
         jsdocErrorLog("Could not detect a node installation");


### PR DESCRIPTION
Tried using your module in Windows and ran into several problems. Here are my fixes to get it working.
- Using the core OS module for figuring out the location of the temp folder and the correct command to run to find node's executable
- Adding quotes around paths. A good practice in general, but it is particularly necessary for the "Program Files" folder due to the space character.
- Sadly, Meteor [doesn't support bash on Windows](https://github.com/meteor/meteor/issues/4938) yet. This means that the first method of starting up the doc's meteor server fails on Windows. There are a few ways of getting around this, but I couldn't be bothered as it's not urgent right now and the second method is good enough.
- Making appropriate changes to the readme file.

I also did another fix which is not specific to Windows. The error objects (particularly those returned by native node modules) are not typically Strings. As a result, using the "color" module's added properties to the String object's prototype would throw errors on these error objects. I used the toString method to get around the problem. Of course, it would be nicer to output the proper stack trace. I was too lazy to add that though. ;)

Thanks for making this module. I've also got a few suggestions for you. You can take it or leave it.
- Instead of the "which" or "where" commands, use node's very own [process.execPath](https://nodejs.org/api/process.html#process_process_execpath).
- Your code is pretty good, :+1:  but it could definitely benefit from some refactoring and maybe a bit more OO.
- Some sort of watch would be good, so the developer wouldn't have to run the build command over and over again.
- Could this perhaps work better as a meteor package instead of an npm module? That way, you can hook into meteor's build pipeline and make use of all the goodies. :)
