### PR TITLE
Include markdown files using @partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,17 @@ find: function(/* selector, options */) {
 }
 ```
 
-Add your own markdown by including a @partial. The partial refers to a template with the same name, so you need to create a mdComplicatedFunction**.partial.md** where you write your markdown documentaion. The syntax is the same as preamble.md.
+### Adding additional markdown files a documentation block
+
+Add your own markdown by including a @partial. Make sure you have enabled "markdownInPartial" in `jsdoc.json` (**NOT** enabled by default). 
+
+```js
+  "markdownInPartial": true
+```
+
+The partial refers to a template with the same name, so you need to create a **.partial.md** file where you write your markdown documentaion.
+When building the docs, your files will be found (you can place them anywhere but the .meteor and node_modules directories) and copied inside <docsPath>/client/templates.
+The syntax is the same as preamble.md, but unlike preamble, your partials will be overwritten on every build.
 
 ```js
 /**

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Meteor JSDoc is a command line tool which will help with generating documentatio
 * The generated docs are used as data by a Meteor app which displays a nicely formatted documentation for your app (like the [Meteor Docs](http://docs.meteor.com/#/full/)) at `http://localhost/3333/` (configurable).
 * A configuration file allows project based configuration, avoiding problem of _port already in use_.
 * Markdown supported in `@summary`, `@example` & description in `@param`.
+* Markdown templates can be included by using `@partial`.
 
 ### Installation
 
@@ -73,6 +74,8 @@ This will create a config file in your Meteor project directory:
       "description": "Documentation for a meteor project."
     }
   }
+  // Allows for inclusion of markdown templates using the @partial keyword.
+  "markdownInPartial": false
 }
 ```
 
@@ -181,6 +184,29 @@ Mongo.Collection = function(name, options) {
 find: function(/* selector, options */) {
   /** ... **/
 }
+```
+
+Add your own markdown by including a @partial. The partial refers to a template with the same name, so you need to create a mdComplicatedFunction**.partial.md** where you write your markdown documentaion. The syntax is the same as preamble.md.
+
+```js
+/**
+ * @summary A highly complicated function that needs more documentation
+ * @locus Anywhere
+ * @partial mdComplicatedFunction
+ * @returns {Object}
+ */
+```
+
+In mdComplicatedFunction.partial.md:
+
+```markdown
+{{#template name="mdComplicatedFunction"}}
+
+### Using complicatedFunction
+
+.. .. ..
+
+{{/template}}
 ```
 
 ### Building the docs

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Add your own markdown by including a `@partial` tag. Make sure you have enabled 
 ```
 
 The partial refers to a template with the same name, so you need to create a **.partial.md** file where you write your markdown documentaion.
-When building the docs, your files will be found (you can place them anywhere but the .meteor and node_modules directories) and copied inside <docsPath>/client/templates.
+When building the docs, your files will be found (you can place them anywhere but the .meteor and node_modules directories) and copied inside <docsPath>/client/templates. A good place to have these files could be in a `/docs/` directory.
 The syntax is the same as preamble.md, but unlike preamble, your partials will be overwritten on every build.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Meteor JSDoc is a command line tool which will help with generating documentatio
 - [Config file](#config-file)
 - [Preamble](#preamble)
 - [Adding documentation to your project](#adding-documentation-to-your-project)
+- [Adding additional markdown files a documentation block](#adding-additional-markdown-files-a-documentation-block)
 - [Building the docs](#building-the-docs)
 - [Starting the Meteor server](#starting-the-meteor-server)
 - [Stopping the Meteor server](#stopping-the-meteor-server)
@@ -188,7 +189,7 @@ find: function(/* selector, options */) {
 
 ### Adding additional markdown files a documentation block
 
-Add your own markdown by including a @partial. Make sure you have enabled "markdownInPartial" in `jsdoc.json` (**NOT** enabled by default). 
+Add your own markdown by including a `@partial` tag. Make sure you have enabled "markdownInPartial" in `jsdoc.json` (**NOT** enabled by default). 
 
 ```js
   "markdownInPartial": true

--- a/example/jsdoc.json
+++ b/example/jsdoc.json
@@ -23,5 +23,7 @@
     "metas": {
       "description": "Documentation for a meteor project."
     }
-  }
+  },
+  // Allows for inclusion of markdown templates using the @partial keyword.
+  "markdownInPartial": false
 }

--- a/example/meteor/client/helpers.js
+++ b/example/meteor/client/helpers.js
@@ -52,11 +52,3 @@ Template.registerHelper("type", function(what) {
 Template.registerHelper("depthIs", function(n) {
   return this.depth === n;
 });
-
-Template.registerHelper("isNamespace", function(kind) {
-  return kind === "namespace";
-});
-
-Template.registerHelper("hasPartial", function(partial) {
-  return !!partial;
-});

--- a/example/meteor/client/helpers.js
+++ b/example/meteor/client/helpers.js
@@ -18,12 +18,12 @@ Template.registerHelper("sections", function() {
       } else {
         let localDepth = depth;
         if (typeof(item) === "string") {
-          if (item.split("#").length > 1) {
-            localDepth += 1;
-          }
-          if (item.split(".").length > 1) {
-            localDepth += 1;
-          }
+          // if (item.split("#").length > 1) {
+          //   localDepth += 1;
+          // }
+          // if (item.split(".").length > 1) {
+          //   localDepth += 1;
+          // }
           item = { name: item, depth: localDepth };
         }
 

--- a/example/meteor/client/helpers.js
+++ b/example/meteor/client/helpers.js
@@ -16,19 +16,12 @@ Template.registerHelper("sections", function() {
           ret.push({ type: "spacer", depth: 2 });
         }
       } else {
-        let localDepth = depth;
         if (typeof(item) === "string") {
-          // if (item.split("#").length > 1) {
-          //   localDepth += 1;
-          // }
-          // if (item.split(".").length > 1) {
-          //   localDepth += 1;
-          // }
-          item = { name: item, depth: localDepth };
+          item = { name: item };
         }
 
         let id = item.name.replace(/[.#]/g, "-");
-        
+
         ret.push(_.extend({ type: "section", depth: depth, id: id, }, item));
       }
     });

--- a/example/meteor/client/helpers.js
+++ b/example/meteor/client/helpers.js
@@ -16,12 +16,19 @@ Template.registerHelper("sections", function() {
           ret.push({ type: "spacer", depth: 2 });
         }
       } else {
+        let localDepth = depth;
         if (typeof(item) === "string") {
-          item = {name: item};
+          if (item.split("#").length > 1) {
+            localDepth += 1;
+          }
+          if (item.split(".").length > 1) {
+            localDepth += 1;
+          }
+          item = { name: item, depth: localDepth };
         }
 
         let id = item.name.replace(/[.#]/g, "-");
-
+        
         ret.push(_.extend({ type: "section", depth: depth, id: id, }, item));
       }
     });

--- a/example/meteor/client/helpers.js
+++ b/example/meteor/client/helpers.js
@@ -49,3 +49,7 @@ Template.registerHelper("depthIs", function(n) {
 Template.registerHelper("isNamespace", function(kind) {
   return kind === "namespace";
 });
+
+Template.registerHelper("hasPartial", function(partial) {
+  return !!partial;
+});

--- a/example/meteor/client/helpers.js
+++ b/example/meteor/client/helpers.js
@@ -45,3 +45,7 @@ Template.registerHelper("type", function(what) {
 Template.registerHelper("depthIs", function(n) {
   return this.depth === n;
 });
+
+Template.registerHelper("isNamespace", function(kind) {
+  return kind === "namespace";
+});

--- a/example/meteor/client/templates/api-box.html
+++ b/example/meteor/client/templates/api-box.html
@@ -15,57 +15,63 @@
 <template name="autoApiBox">
   {{#with apiData this}}
 
-    {{#markdown}}{{before}}{{/markdown}}
+    {{#if isNamespace kind}}
+      {{#markdown}}{{before}}{{/markdown}}
+      {{#markdown}}{{summary}}{{/markdown}}
+      {{#markdown}}{{after}}{{/markdown}}
+    {{else}}
+    
+      {{#markdown}}{{before}}{{/markdown}}
+      
+      <div class="api new-api-box">
+        {{> apiBoxTitle name=signature locus=locus id=id filepath=filepath lineno=lineno}}
 
-    <div class="api new-api-box">
-      {{> apiBoxTitle name=signature locus=locus id=id filepath=filepath lineno=lineno}}
-
-      <div class="desc">
-        {{#if typeNames}}
+        <div class="desc">
           <p>
-            <span class="type">{{{typeNames}}}</span>
+            {{#if typeNames}}
+              <span class="type">{{{typeNames}}}</span>
+            {{/if}}
           </p>
+          {{#markdown}}{{summary}}{{/markdown}}
+        </div>
+      
+        {{#if arguments}}
+          <h4>Arguments</h4>
+          <dl class="args">
+            {{#each arguments}}
+              {{> api_box_args}}
+            {{/each}}
+          </dl>
         {{/if}}
-        {{#markdown}}{{summary}}{{/markdown}}
+
+        {{#each specialArguments}}
+          <h4>{{this.name}}</h4>
+          <dl class="args">
+            {{#each this.arguments}}
+              {{> api_box_args}}
+            {{/each}}
+          </dl>
+        {{/each}}
+
+        {{#if returns}}
+          <h4>Returns</h4>
+          <dl class="args">
+            {{#each returns}}
+                {{> api_box_args}}
+            {{/each}}
+          </dl>
+        {{/if}}
+
+        {{#if examples}}
+          <h4>Example</h4>
+        {{/if}}
+        {{#each examples}}
+          {{> api_box_eg}}
+        {{/each}}
       </div>
-
-      {{#if arguments}}
-        <h4>Arguments</h4>
-        <dl class="args">
-          {{#each arguments}}
-            {{> api_box_args}}
-          {{/each}}
-        </dl>
-      {{/if}}
-
-      {{#each specialArguments}}
-        <h4>{{this.name}}</h4>
-        <dl class="args">
-          {{#each this.arguments}}
-            {{> api_box_args}}
-          {{/each}}
-        </dl>
-      {{/each}}
-
-      {{#if returns}}
-        <h4>Returns</h4>
-        <dl class="args">
-          {{#each returns}}
-            {{> api_box_args}}
-          {{/each}}
-        </dl>
-      {{/if}}
-
-      {{#if examples}}
-        <h4>Example</h4>
-      {{/if}}
-      {{#each examples}}
-        {{> api_box_eg}}
-      {{/each}}
-    </div>
-
-    {{#markdown}}{{after}}{{/markdown}}
-
+      
+      {{#markdown}}{{after}}{{/markdown}}
+    {{/if}}
   {{/with}}
 </template>
 

--- a/example/meteor/client/templates/api-box.html
+++ b/example/meteor/client/templates/api-box.html
@@ -1,6 +1,7 @@
 <template name="apiBoxTitle">
   <h3 id="{{id}}" class="api-title">
     <a class="name selflink" href="#{{id}}" name="{{id}}">{{{name}}}</a>
+    <a class="src-code">{{filepath}}, line {{lineno}}</a>
     {{#if locus}}
       <span class="locus">{{locus}}</span>
     {{/if}}

--- a/example/meteor/client/templates/api-box.html
+++ b/example/meteor/client/templates/api-box.html
@@ -19,10 +19,12 @@
       {{#markdown}}{{before}}{{/markdown}}
       {{#markdown}}{{summary}}{{/markdown}}
       {{#markdown}}{{after}}{{/markdown}}
+      
+      {{#if hasPartial partial}}
+        {{> Template.dynamic template=partial}}
+      {{/if}}
     {{else}}
     
-      {{#markdown}}{{before}}{{/markdown}}
-      
       <div class="api new-api-box">
         {{> apiBoxTitle name=signature locus=locus id=id filepath=filepath lineno=lineno}}
 
@@ -71,6 +73,11 @@
       </div>
       
       {{#markdown}}{{after}}{{/markdown}}
+      
+      {{#if hasPartial partial}}
+        {{> Template.dynamic template=partial}}
+      {{/if}}
+      
     {{/if}}
   {{/with}}
 </template>

--- a/example/meteor/client/templates/api-box.html
+++ b/example/meteor/client/templates/api-box.html
@@ -1,7 +1,6 @@
 <template name="apiBoxTitle">
   <h3 id="{{id}}" class="api-title">
     <a class="name selflink" href="#{{id}}" name="{{id}}">{{{name}}}</a>
-    <a class="src-code">{{filepath}}, line {{lineno}}</a>
     {{#if locus}}
       <span class="locus">{{locus}}</span>
     {{/if}}

--- a/example/meteor/client/templates/api-box.html
+++ b/example/meteor/client/templates/api-box.html
@@ -15,70 +15,61 @@
 <template name="autoApiBox">
   {{#with apiData this}}
 
-    {{#if isNamespace kind}}
-      {{#markdown}}{{before}}{{/markdown}}
-      {{#markdown}}{{summary}}{{/markdown}}
-      {{#markdown}}{{after}}{{/markdown}}
-      
-      {{#if hasPartial partial}}
-        {{> Template.dynamic template=partial}}
-      {{/if}}
-    {{else}}
-    
-      <div class="api new-api-box">
-        {{> apiBoxTitle name=signature locus=locus id=id filepath=filepath lineno=lineno}}
+    {{#markdown}}{{before}}{{/markdown}}
 
-        <div class="desc">
+    <div class="api new-api-box">
+      {{> apiBoxTitle name=signature locus=locus id=id filepath=filepath lineno=lineno}}
+
+      <div class="desc">
+        {{#if typeNames}}
           <p>
-            {{#if typeNames}}
-              <span class="type">{{{typeNames}}}</span>
-            {{/if}}
+            <span class="type">{{{typeNames}}}</span>
           </p>
-          {{#markdown}}{{summary}}{{/markdown}}
-        </div>
-      
-        {{#if arguments}}
-          <h4>Arguments</h4>
-          <dl class="args">
-            {{#each arguments}}
-              {{> api_box_args}}
-            {{/each}}
-          </dl>
         {{/if}}
-
-        {{#each specialArguments}}
-          <h4>{{this.name}}</h4>
-          <dl class="args">
-            {{#each this.arguments}}
-              {{> api_box_args}}
-            {{/each}}
-          </dl>
-        {{/each}}
-
-        {{#if returns}}
-          <h4>Returns</h4>
-          <dl class="args">
-            {{#each returns}}
-                {{> api_box_args}}
-            {{/each}}
-          </dl>
-        {{/if}}
-
-        {{#if examples}}
-          <h4>Example</h4>
-        {{/if}}
-        {{#each examples}}
-          {{> api_box_eg}}
-        {{/each}}
+        {{#markdown}}{{summary}}{{/markdown}}
       </div>
-      
-      {{#markdown}}{{after}}{{/markdown}}
-      
-      {{#if hasPartial partial}}
-        {{> Template.dynamic template=partial}}
+
+      {{#if arguments}}
+        <h4>Arguments</h4>
+        <dl class="args">
+          {{#each arguments}}
+            {{> api_box_args}}
+          {{/each}}
+        </dl>
       {{/if}}
-      
+
+      {{#each specialArguments}}
+        <h4>{{this.name}}</h4>
+        <dl class="args">
+          {{#each this.arguments}}
+            {{> api_box_args}}
+          {{/each}}
+        </dl>
+      {{/each}}
+
+      {{#if returns}}
+        <h4>Returns</h4>
+        <dl class="args">
+          {{#each returns}}
+            {{> api_box_args}}
+          {{/each}}
+        </dl>
+      {{/if}}
+
+      {{#if examples}}
+        <h4>Example</h4>
+      {{/if}}
+      {{#each examples}}
+        {{> api_box_eg}}
+      {{/each}}
+    </div>
+
+    {{#markdown}}{{after}}{{/markdown}}
+    
+    {{#if partial}}
+      {{> Template.dynamic template=partial}}
     {{/if}}
+
   {{/with}}
 </template>
 

--- a/example/meteor/client/templates/docs.html
+++ b/example/meteor/client/templates/docs.html
@@ -17,7 +17,7 @@
             {{/if}}
             {{#if type "section"}}
               {{#if depthIs 1}}
-                <h1 id="{{name}}">{{name}}</h1>
+                <h2 id="{{name}}">{{name}}</h2>
               {{else}}
                 {{> autoApiBox this}}
               {{/if}}
@@ -38,18 +38,4 @@
     {{/if}}
     {{> tableOfContents}}
   </div>
-</template>
-
-<template name="dtdd">
-  {{! can be used with either one argument (which ends up in the data
-      context, or with both name and type }}
-
-  {{#if name}}
-    <dt><span class="name" id={{#if id}}{{id}}{{/if}}>{{{name}}}</span>
-      {{#if type}}<span class="type">{{type}}</span>{{/if}}
-    </dt>
-  {{else}}
-    <dt><span class="name">{{{.}}}</span></dt>
-  {{/if}}
-  <dd>{{#markdown}}{{> UI.contentBlock}}{{/markdown}}</dd>
 </template>

--- a/example/meteor/client/templates/docs.html
+++ b/example/meteor/client/templates/docs.html
@@ -17,7 +17,7 @@
             {{/if}}
             {{#if type "section"}}
               {{#if depthIs 1}}
-                <h2 id="{{name}}">{{name}}</h2>
+                <h1 id="{{name}}">{{name}}</h1>
               {{else}}
                 {{> autoApiBox this}}
               {{/if}}
@@ -38,4 +38,18 @@
     {{/if}}
     {{> tableOfContents}}
   </div>
+</template>
+
+<template name="dtdd">
+  {{! can be used with either one argument (which ends up in the data
+      context, or with both name and type }}
+
+  {{#if name}}
+    <dt><span class="name" id={{#if id}}{{id}}{{/if}}>{{{name}}}</span>
+      {{#if type}}<span class="type">{{type}}</span>{{/if}}
+    </dt>
+  {{else}}
+    <dt><span class="name">{{{.}}}</span></dt>
+  {{/if}}
+  <dd>{{#markdown}}{{> UI.contentBlock}}{{/markdown}}</dd>
 </template>

--- a/example/meteor/client/templates/docs.less
+++ b/example/meteor/client/templates/docs.less
@@ -302,6 +302,7 @@ dl.callbacks {
 
 .api h3,
 h3.api-title {
+  position:relative;
   background: #eee;
   padding   : 5px 10px;
 }
@@ -369,8 +370,15 @@ ol {
 }
 
 .api-title .locus {
+<<<<<<< HEAD
   float        : right;
   font-weight  : normal;
+=======
+  position: absolute;
+  top: 5px;
+  right: 10px;
+  font-weight: normal;
+>>>>>>> fix locus positioning in api-title
   padding-right: 5px;
   font-style   : italic;
 }

--- a/example/meteor/client/templates/docs.less
+++ b/example/meteor/client/templates/docs.less
@@ -302,7 +302,6 @@ dl.callbacks {
 
 .api h3,
 h3.api-title {
-  position:relative;
   background: #eee;
   padding   : 5px 10px;
 }
@@ -370,9 +369,7 @@ ol {
 }
 
 .api-title .locus {
-  position     : absolute;
-  top          : 5px;
-  right        : 10px;
+  float        : right;
   font-weight  : normal;
   padding-right: 5px;
   font-style   : italic;

--- a/example/meteor/client/templates/docs.less
+++ b/example/meteor/client/templates/docs.less
@@ -370,15 +370,10 @@ ol {
 }
 
 .api-title .locus {
-<<<<<<< HEAD
-  float        : right;
+  position     : absolute;
+  top          : 5px;
+  right        : 10px;
   font-weight  : normal;
-=======
-  position: absolute;
-  top: 5px;
-  right: 10px;
-  font-weight: normal;
->>>>>>> fix locus positioning in api-title
   padding-right: 5px;
   font-style   : italic;
 }

--- a/example/meteor/client/templates/docs.less
+++ b/example/meteor/client/templates/docs.less
@@ -831,6 +831,14 @@ pre {
     padding-left: 20px;
     color       : #333;
   }
+  
+  h5 {
+    font-size   : 0.8em;
+    font-weight : normal;
+    margin      : 4px 0;
+    padding-left: 30px;
+    color       : #333;
+  }
 
   .spacer {
     height: 0.33em;

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -235,9 +235,9 @@ Actions.prototype.build = function() {
         } else {
           if (self.config.markdownInPartial) {
             self.markdown();
+          } else {
+            helpers.success("Docs successfully built.");
           }
-          
-          helpers.success("Docs successfully built.");
         }
       }
     }
@@ -262,10 +262,11 @@ Actions.prototype.markdown = function() {
     } else {
       var files = logs.stdout.split(" ");
       _.each(files, function (f) {
-        helpers.debug("copied " + f);
+        helpers.info("Copied " + f);
       });
 
       helpers.info("Markdown templates were copied.");
+      helpers.success("Docs successfully built.");
     }
   });
 };

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -262,7 +262,7 @@ Actions.prototype.markdown = function() {
     } else {
       var files = logs.stdout.split(" ");
       _.each(files, function (f) {
-        helpers.log(f);
+        helpers.debug("copied " + f);
       });
 
       helpers.info("Markdown templates were copied.");

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -233,9 +233,39 @@ Actions.prototype.build = function() {
           });
           helpers.warn("Docs built with errors.");
         } else {
+          if (self.config.markdownInPartial) {
+            self.markdown();
+          }
+          
           helpers.success("Docs successfully built.");
         }
       }
+    }
+  });
+};
+
+
+Actions.prototype.markdown = function() {
+  var self = this;
+
+  var get_markdown = {
+    script: path.resolve(SCRIPT_DIR, "copy_markdown.sh"),
+    vars: {
+      docsPath  : self.config.docsPath,
+      projectPath  : path.resolve("."),
+    }
+  };
+
+  self._executeScript(get_markdown.script, get_markdown.vars, function(err, code, logs) {
+    if (err) {
+      helpers.error(err);
+    } else {
+      var files = logs.stdout.split(" ");
+      _.each(files, function (f) {
+        helpers.log(f);
+      });
+
+      helpers.info("Markdown templates were copied.");
     }
   });
 };

--- a/scripts/copy_markdown.sh
+++ b/scripts/copy_markdown.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd <%= projectPath %>
+echo `find . -type f -name "*.partial.md" ! -path "*/.meteor/" ! -path "*/node_modules/*"`
+find . -type f -name "*.partial.md" ! -path "*/.meteor/" ! -path "*/node_modules/*" -exec cp -f {} "<%= docsPath %>/client/templates" \;


### PR DESCRIPTION
I think we can resolve #26 using `@partial` and have your extra documentation files in a sensible place, like `/docs/`or `/markdown`.

These changes however will allow you to have your .md files wherever you want, as long as you call your files <filename>.partial.md and define a template name like in preamble.md.
