### PR TITLE
Fix issue generating TC from preamble when templates are rendered.

### DIFF
--- a/example/meteor/client/templates/preamble-toc.js
+++ b/example/meteor/client/templates/preamble-toc.js
@@ -1,7 +1,7 @@
 Template.preambleToc.helpers({
   links() {
     if (Template.preamble) {
-      let preambleHtml = Template.preamble.renderFunction().value;
+      let preambleHtml = UI.toHTML(Template.preamble);
       let toParse      = $("<div/>").append(preambleHtml);
 
       return toParse.find("[id]").toArray();


### PR DESCRIPTION
If preamble.md renders other templates using {{> template}} syntax, errors occur in this code.

Using UI.toHTML instead fixes this, and the table of contents is generated correctly.
