### PR TITLE
Improve the namespace parser to split on # too

### DIFF
--- a/example/meteor/client/helpers.js
+++ b/example/meteor/client/helpers.js
@@ -34,7 +34,7 @@ Template.registerHelper("sections", function() {
     });
   };
 
-  let namespaces = _.groupBy(DocsNames, name => name.split('.')[0]);
+  let namespaces = _.groupBy(DocsNames, name => name.split(/[\.#]+/)[0]);
 
   let toc = _.chain(namespaces).map(
     (functions, namespace) => [namespace, functions]


### PR DESCRIPTION
Hi,

During my internship I wanted to use the jsdoc but I had issue to get a object and all it's functionnalities regrouped in a nice single namespace.
This pull request correct this:

**Foo**
    - Foo
    - Foo.get
**Foo#instance**
    - Foo#instance

into

**Foo**
    - Foo
    - Foo#instance
    - Foo.get

Which is a little bit better !
