### PR TITLE
Add missing underscore.js import

### DIFF
--- a/template/publish.js
+++ b/template/publish.js
@@ -11,6 +11,7 @@
   const extend    = require("lodash/extend");
   const stringify = require("canonical-json");
   const path      = require("path");
+  const _         = require("underscore");
 
   // This is the big map of name -> data that we'll write to a file.
   var dataContents = {};


### PR DESCRIPTION
This fix will simply add the underscore object "_" to the scope of the publish.js class.

Consider the example
```
@summary XYZ
@param {Object} [options]
@param options.one
@param options.two.three
```

options.one will be parsed as expected but for options.two.three there will be a log error complaining about a unknown underscore object.

```
"Generating output files..."
"/opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/template/publish.js:146"
"          param.name = _.rest(splitName).join(\".\");"
"                       ^"

"ReferenceError: _ is not defined"
"    at /opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/template/publish.js:146:24"
"    at arrayEach (/opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/node_modules/lodash/_arrayEach.js:15:9)"
"    at forEach (/opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/node_modules/lodash/forEach.js:36:7)"
"    at /opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/template/publish.js:133:7"
"    at arrayEach (/opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/node_modules/lodash/_arrayEach.js:15:9)"
"    at forEach (/opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/node_modules/lodash/forEach.js:36:7)"
"    at Object.exports.publish (/opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/template/publish.js:120:5)"
"    at Object.module.exports.cli.generateDocs (/opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/node_modules/jsdoc/cli.js:430:39)"
"    at Object.module.exports.cli.processParseResults (/opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/node_modules/jsdoc/cli.js:383:20)"
"    at module.exports.cli.main (/opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/node_modules/jsdoc/cli.js:227:14)"
"    at Object.module.exports.cli.runCommand (/opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/node_modules/jsdoc/cli.js:180:5)"
"    at /opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/node_modules/jsdoc/jsdoc.js:103:9"
"    at Object.<anonymous> (/opt/nodejs/node-v6.9.5-linux-x64/lib/node_modules/meteor-jsdoc/node_modules/jsdoc/jsdoc.js:104:3)"
"    at Module._compile (module.js:570:32)"
"    at Object.Module._extensions..js (module.js:579:10)"
"    at Module.load (module.js:487:32)"
```
